### PR TITLE
feat(#9) Toast 컴포넌트 sucess/error 분기 처리 및 스타일 수정

### DIFF
--- a/src/assets/alert.svg
+++ b/src/assets/alert.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#EC0037" stroke="#EC0037" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 8V12" stroke="#FCD6DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 16H12.01" stroke="#FCD6DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/check.svg
+++ b/src/assets/check.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="24" height="24" rx="12" fill="#14C786"/>
+<path d="M18.33 8L9.85312 16.4769L6 12.6238" stroke="#FAFAFA" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,20 +1,45 @@
-interface ToastProps {
-  toast: {
-    message: string
-    type: 'success' | 'error'
-  } | null
-}
+import type { ToastProps } from '@/types/common/Toast'
+import checkIcon from '@/assets/check.svg'
+import errorIcon from '@/assets/alert.svg'
 
-export const Toast = ({ toast }: ToastProps) => {
+export const Toast = ({ toast }: { toast: ToastProps | null }) => {
   if (!toast) return null
 
-  const bgColor = toast.type === 'success' ? 'bg-green-500' : 'bg-red-500'
+  const isError = toast.type === 'error'
+  const icon = isError ? errorIcon : checkIcon
+  const centeredTitleColor = isError ? 'text-[#ec0037]' : 'text-[#121212]'
+  const defaultTextColor = isError ? 'text-[#ec0037]' : 'text-[#4d4d4d]'
+
+  if (toast.layout === 'centered') {
+    return (
+      <div className="fixed flex flex-col items-center gap-2 justify-center w-[396px] h-[128px] top-[422px] left-[762px] bg-[#ffffff] rounded-[12px] text-center ">
+        <div className="w-[24px] h-[24px]">
+          <img src={icon} alt={toast.type} className="w-full h-full" />
+        </div>
+        <div
+          className={`text-[20px] ${centeredTitleColor} font-bold leading-[1.4] tracking-[-0.03em]`}
+        >
+          {toast.message}
+        </div>
+        {toast.subMessage && (
+          <div className="text-sm text-[#4d4d4d] leading-[1.4] tracking-[-0.03em]">
+            {toast.subMessage}
+          </div>
+        )}
+      </div>
+    )
+  }
 
   return (
     <div
-      className={`fixed left-1/2 bottom-1/2 -translate-x-1/2 px-4 py-2 rounded text-white ${bgColor}`}
+      className={`fixed top-[204px] left-[836px] flex items-center w-[248px] h-[48px] pl-1 px-3 bg-[#fafafa] border border-[#ECECEC] rounded-md [box-shadow:4px_4px_4px_0_rgba(131,131,131,0.25)] ${toast.className || ''}`}
     >
-      {toast.message}
+      <img src={icon} alt={toast.type} className="w-[24px] h-[24px] mr-1" />
+      <span
+        className={`text-[14px] font-medium leading-[1.4] tracking-[-0.03em] ${defaultTextColor} whitespace-nowrap`}
+      >
+        {toast.message}
+      </span>
     </div>
   )
 }

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -32,7 +32,7 @@ export const Toast = ({ toast }: { toast: ToastProps | null }) => {
 
   return (
     <div
-      className={`fixed top-[204px] left-[836px] flex items-center w-[248px] h-[48px] pl-1 px-3 bg-[#fafafa] border border-[#ECECEC] rounded-md [box-shadow:4px_4px_4px_0_rgba(131,131,131,0.25)] ${toast.className || ''}`}
+      className={`fixed top-[204px] left-[836px] flex items-center w-[248px] h-[48px] pl-2 px-3 bg-[#fafafa] border border-[#ECECEC] rounded-md [box-shadow:4px_4px_4px_0_rgba(131,131,131,0.25)] ${toast.className || ''}`}
     >
       <img src={icon} alt={toast.type} className="w-[24px] h-[24px] mr-1" />
       <span

--- a/src/context/ToastBoxContext.tsx
+++ b/src/context/ToastBoxContext.tsx
@@ -1,8 +1,5 @@
 import { createContext } from 'react'
-
-type ToastContextType = {
-  showToast: (options: { message: string; type: 'success' | 'error' }) => void
-}
+import type { ToastContextType } from '@/types/common/Toast'
 
 export const ToastContext = createContext<ToastContextType>({
   showToast: () => {},

--- a/src/context/ToastBoxProvider.tsx
+++ b/src/context/ToastBoxProvider.tsx
@@ -1,11 +1,7 @@
 import React, { useState } from 'react'
 import { ToastContext } from '@/context/ToastBoxContext'
 import { Toast } from '@/components/common/Toast'
-
-export interface ToastProps {
-  message: string
-  type: 'success' | 'error'
-}
+import type { ToastProps } from '@/types/common/Toast'
 
 interface ToastBoxProviderProps {
   children: React.ReactNode
@@ -14,9 +10,15 @@ interface ToastBoxProviderProps {
 export const ToastBoxProvider = ({ children }: ToastBoxProviderProps) => {
   const [toast, setToast] = useState<ToastProps | null>(null)
 
-  const showToast = ({ message, type }: ToastProps) => {
-    setToast({ message, type })
-    setTimeout(() => setToast(null), 3000)
+  const showToast = ({
+    message,
+    type,
+    className,
+    layout,
+    subMessage,
+  }: ToastProps) => {
+    setToast({ message, type, className, layout, subMessage })
+    setTimeout(() => setToast(null), 4000)
   }
 
   return (

--- a/src/types/common/Toast.ts
+++ b/src/types/common/Toast.ts
@@ -1,0 +1,17 @@
+export type ToastContextType = {
+  showToast: (options: {
+    message: string
+    type: 'success' | 'error'
+    className?: string
+    layout?: 'inline' | 'centered'
+    subMessage?: string
+  }) => void
+}
+
+export type ToastProps = {
+  message: string
+  type: 'success' | 'error'
+  className?: string
+  layout?: 'inline' | 'centered'
+  subMessage?: string
+}


### PR DESCRIPTION
1. 타입 외부로 분리
2. Toast Props로 success, error 제어 할 수 있게 개발
3. layout inline과 centered 두 가지로 분리하여 각 각 다른 스타일을 가질 수 있게 개발
4. inline에서는 메세지만 입력 가능하게, centered에서는 서브 메세지까지 가능하게 개발